### PR TITLE
_get_workbook_path returns extension instead of filename

### DIFF
--- a/XLMMacroDeobfuscator/xlsm_wrapper.py
+++ b/XLMMacroDeobfuscator/xlsm_wrapper.py
@@ -108,6 +108,8 @@ class XLSMWrapper(ExcelWrapper):
                 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml']
         elif 'application/vnd.ms-excel.sheet.macroEnabled.main+xml' in self._types:
             workbook_path = self._types['application/vnd.ms-excel.sheet.macroEnabled.main+xml']
+        if workbook_path == 'xml': # type has extension and not filename
+            workbook_path = 'xl/workbook.xml'
         workbook_path = workbook_path.lstrip('/')
 
         path=''


### PR DESCRIPTION
This fixes a bug in the XLSMWrapper class that sometimes causes workbooks to not get loaded, which causes process_file to crash